### PR TITLE
Updates the hosts file with all of the hosts given on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ I dunno. If you want to be a peer of tilde.club then you could add
 your IP here? Nothing is implemented. I'm just putting it here as a
 kind of placeholder for some things to figure out later.
 
+## host-gen.py
+The host-gen.py script can be used to dynamically recreate the hosts file. It will create a new file called host-data in the current directory, which should be manually verified prior to overwriting the existing /etc/hosts file.

--- a/host-gen.py
+++ b/host-gen.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+import json
+import sys,socket,os
+from urlparse import urlparse
+import urllib2
+
+try:
+    os.remove('host-data')
+except OSError:
+    pass #silenty fail to not delete file
+json_data=urllib2.urlopen('http://tilde.club/~pfhawkins/othertildes.json')
+data = json.load(json_data)
+#manually add the tilde.club as it isn't in the JSON returned
+data['tilde.club'] = 'http://tilde.club'
+for attribute, value in data.iteritems():
+    with open("host-data", "a") as hfile:
+        ur = urlparse(value)
+        hfile.write("#{0}\n{1} {2}\n".format(attribute, socket.gethostbyname(ur.netloc), ur.netloc))
+json_data.close()

--- a/hosts
+++ b/hosts
@@ -1,1 +1,46 @@
-54.210.84.216   tilde.club
+#hypertext website
+54.186.135.114 hypertext.website
+#remotes club
+208.83.223.139 remotes.club
+#tilde city
+167.88.34.185 tilde.city
+#sunburnt country
+54.66.147.120 sunburnt.country
+#tilde town
+54.69.163.190 tilde.town
+#tilde farm
+23.239.16.170 tilde.farm
+#bleepbloop club
+54.68.131.4 bleepbloop.club
+#RIOTGIRL.CLUB
+104.236.1.216 riotgirl.club
+#palvelin club
+83.136.248.66 palvelin.club
+#protocol club
+104.131.60.69 protocol.club
+#yesterhost
+104.131.160.23 yester.host
+#german tilde
+54.72.245.137 germantil.de
+#tilde camp
+130.211.124.203 tilde.camp
+#catbeard city
+81.4.104.158 catbeard.city
+#tilde center
+23.94.65.174 tilde.center
+#drawbridge club
+54.191.52.238 drawbridge.club
+#totally nuclear club
+54.164.45.71 totallynuclear.club
+#retronet
+104.200.20.92 retronet.net
+#cybyte club
+54.69.62.189 cybyte.club
+#squiggle city
+104.131.119.171 squiggle.city
+#tilde red
+172.245.183.173 tilde.red
+#tilde.club
+54.165.138.240 tilde.club
+#rudimentary lathe
+104.200.16.251 rudimentarylathe.org


### PR DESCRIPTION
The JSON list here: http://tilde.club/~pfhawkins/othertildes.json provides a (partial?) list of tilde.club servers, I wrote a little script which extracts the json and generates a valid Linux hosts file.  From the issue listed, this may be useful if AWS's DNS manager is used. The script I used to generate the file is available as a gist: https://gist.github.com/lbearl/6222e98f6e51173a69e5